### PR TITLE
Implement alphanumeric CNPJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,5 @@ __pycache__/
 
 # Coverage Report
 covarge_report.xml
+results/
+*.claude/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-conventions](https://www.conventionalcommits.org/en/v1.0.0/#specification) for commit guidelines.
 
+
+### 1.0.3 (2026-05-13)
+
+### 🎉 Features
+* **project:** Includes validation for cnpj alphanumeric, according to the standard defined by the (Receita Federal)[https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/perguntas-e-respostas/cnpj/cnpj-alfanumerico.pdf3,], who starts in 07/01/2026.
+
+
 ### 1.0.2 (2021-04-21)
 
 

--- a/FluentValidation.Extensions.Br.sln
+++ b/FluentValidation.Extensions.Br.sln
@@ -1,11 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11709.299
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentValidation.Extensions.Br.Test", "test\FluentValidation.Extensions.Br.Test\FluentValidation.Extensions.Br.Test.csproj", "{08D3645C-13D0-4819-9639-48AD7BE091BA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentValidation.Extensions.Br", "src\FluentValidation.Extensions.Br\FluentValidation.Extensions.Br.csproj", "{8FBC1BB6-579D-4CAD-AA47-EB6D122B5B4C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DEEABD46-4362-4A70-BC4F-98F13657098C}"
+	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentValidator.Extensions.Br.Tests.Api", "test\FluentValidator.Extensions.Br.Tests.Api\FluentValidator.Extensions.Br.Tests.Api.csproj", "{6D709D67-D146-4305-9CFD-2328B23BD7DC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +29,10 @@ Global
 		{8FBC1BB6-579D-4CAD-AA47-EB6D122B5B4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FBC1BB6-579D-4CAD-AA47-EB6D122B5B4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8FBC1BB6-579D-4CAD-AA47-EB6D122B5B4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D709D67-D146-4305-9CFD-2328B23BD7DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D709D67-D146-4305-9CFD-2328B23BD7DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D709D67-D146-4305-9CFD-2328B23BD7DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D709D67-D146-4305-9CFD-2328B23BD7DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/FluentValidation.Extensions.Br/FluentValidation.Extensions.Br.csproj
+++ b/src/FluentValidation.Extensions.Br/FluentValidation.Extensions.Br.csproj
@@ -1,33 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Extensions.FluentValidation.Br</PackageId>
-    <Product>Extensions.FluentValidation.Br</Product>
-    <Title>Extensions.FluentValidation.Br</Title>
-    <PackageVersion>1.0.2</PackageVersion>
-    <Authors>Lucas Mendes Loureiro</Authors>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>An extension of the fluent validation with a set of Brazilian validations</Description>
-    <Copyright>Copyright © 2017 Lucas Mendes Loureiro</Copyright>
-    <PackageProjectUrl>https://github.com/LucasMendesl/FluentValidation.Extensions.Br</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/LucasMendesl/FluentValidation.Extensions.Br</RepositoryUrl>
-    <PackageLicense>https://github.com/LucasMendesl/FluentValidation.Extensions.Br/blob/master/LICENSE</PackageLicense>
-    <Version>1.0.2</Version>
-    <AssemblyVersion>1.0.0.2</AssemblyVersion>
-    <FileVersion>1.0.0.2</FileVersion>
-    <PackageTags>FluentValidation validation validator extension brazilian</PackageTags>
-    <RepositoryType>git</RepositoryType>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<PackageId>Extensions.FluentValidation.Br</PackageId>
+		<Product>Extensions.FluentValidation.Br</Product>
+		<Title>Extensions.FluentValidation.Br</Title>
+		<PackageVersion>1.0.2</PackageVersion>
+		<Authors>Lucas Mendes Loureiro</Authors>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Description>An extension of the fluent validation with a set of Brazilian validations</Description>
+		<Copyright>Copyright © 2017 Lucas Mendes Loureiro</Copyright>
+		<PackageProjectUrl>https://github.com/LucasMendesl/FluentValidation.Extensions.Br</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/LucasMendesl/FluentValidation.Extensions.Br</RepositoryUrl>
+		<PackageLicense>https://github.com/LucasMendesl/FluentValidation.Extensions.Br/blob/master/LICENSE</PackageLicense>
+		<Version>1.0.2</Version>
+		<AssemblyVersion>1.0.0.2</AssemblyVersion>
+		<FileVersion>1.0.0.2</FileVersion>
+		<PackageTags>FluentValidation validation validator extension brazilian</PackageTags>
+		<RepositoryType>git</RepositoryType>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <IncludeSymbols>True</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+		<IncludeSymbols>True</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.0.4" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentValidation" Version="10.0.4" />
+	</ItemGroup>
 
 </Project>

--- a/src/FluentValidation.Extensions.Br/ValidationExtensions.Brazilian.cs
+++ b/src/FluentValidation.Extensions.Br/ValidationExtensions.Brazilian.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentValidation
+namespace FluentValidation
 {
     using Validators;
 
@@ -9,11 +9,9 @@
     {
         /// <summary>
         /// Defines a 'CNPJ' validator on the current rule builder.
-        /// Validation will fail if the property is null, an empty or the value is a invalid CNPJ         
+        /// Accepts both the current numeric format and the new alphanumeric format (Receita Federal, July 2026).
+        /// Validation will fail if the property is null, empty, or the value is an invalid CNPJ.
         /// </summary>
-        /// <typeparam name="T">Type of object being validated</typeparam>
-        /// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
-        /// <returns>a rule builder with cnpj validation included</returns>
         public static IRuleBuilderOptions<T, string> IsValidCNPJ<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
             return ruleBuilder.SetValidator(new CNPJValidator<T, string>());
@@ -21,14 +19,21 @@
 
         /// <summary>
         /// Defines a 'CPF' validator on the current rule builder.
-        /// Validation will fail if the property is null, an empty or the value is a invalid CPF         
+        /// Validation will fail if the property is null, empty, or the value is an invalid CPF.
         /// </summary>
-        /// <typeparam name="T">Type of object being validated</typeparam>
-        /// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
-        /// <returns>a rule builder with cnpj validation included</returns>
         public static IRuleBuilderOptions<T, string> IsValidCPF<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new CPFValidator<T, string>());
+            return ruleBuilder.SetValidator(new CpfValidator<T, string>());
+        }
+
+        /// <summary>
+        /// Defines a 'CPF or CNPJ' validator on the current rule builder.
+        /// Accepts CPF (11 digits) or CNPJ in any format (numeric or alphanumeric, 14 characters).
+        /// Validation will fail if the property is null, empty, or neither a valid CPF nor a valid CNPJ.
+        /// </summary>
+        public static IRuleBuilderOptions<T, string> IsValidCpfOrCnpj<T>(this IRuleBuilder<T, string> ruleBuilder)
+        {
+            return ruleBuilder.SetValidator(new CPFCNPJValidator<T, string>());
         }
     }
 }

--- a/src/FluentValidation.Extensions.Br/Validators/CNPJValidator.cs
+++ b/src/FluentValidation.Extensions.Br/Validators/CNPJValidator.cs
@@ -4,22 +4,42 @@
     /// <summary>
     /// Ensures that the property value is a valid CNPJ number.
     /// </summary>
+    using System;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+
     public class CNPJValidator<T, TProperty> : GenericPersonValidator<T, TProperty>
     {
-        internal CNPJValidator(int validLength, string errorMessage) 
-            : base(validLength, errorMessage)
-        { }
+        private readonly DateTime _alphaStartDate;
 
-        public CNPJValidator(string errorMessage)
-            : this(14, errorMessage)
-        { }
+        public CNPJValidator(string errorMessage = "O CNPJ é inválido!", DateTime? alphaStartDate = null)
+            : base(errorMessage)
+        {
+            _alphaStartDate = alphaStartDate ?? new DateTime(2026, 7, 1);
+        }
 
-        public CNPJValidator() 
-            : this("O CNPJ é inválido!")
-        { }
-
-        protected override int[] FirstMultiplierCollection => new int[12] { 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
-        protected override int[] SecondMultiplierCollection => new int[13] { 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
+        protected override int ValidLength => 14;
+        protected override int[] FirstMultiplierCollection => new[] { 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
+        protected override int[] SecondMultiplierCollection => new[] { 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
         public override string Name => "CNPJValidator";
+
+        protected override string Sanitize(string value)
+            => Regex.Replace(value, "[^A-Z0-9]", "", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+        // ASCII(char) - 48: digits keep face value (0-9), A=17, B=18 ... Z=42.
+        protected override int[] GetNumericValues(string sanitized)
+            => sanitized.Select(x => (int)x - 48).ToArray();
+
+        public override bool IsValid(ValidationContext<T> context, TProperty value)
+        {
+            if (DateTime.Today < _alphaStartDate)
+            {
+                var raw = value as string ?? string.Empty;
+                if (raw.Any(char.IsLetter))
+                    return false;
+            }
+
+            return base.IsValid(context, value);
+        }
     }
 }

--- a/src/FluentValidation.Extensions.Br/Validators/CPFCNPJValidator.cs
+++ b/src/FluentValidation.Extensions.Br/Validators/CPFCNPJValidator.cs
@@ -1,0 +1,26 @@
+namespace FluentValidation.Validators
+{
+    using System;
+
+    public class CPFCNPJValidator<T, TProperty> : PropertyValidator<T, TProperty>, IBrazilianPropertyValidator
+    {
+        private readonly string _errorMessage;
+        private readonly CpfValidator<T, TProperty> _cpf;
+        private readonly CNPJValidator<T, TProperty> _cnpj;
+
+        public CPFCNPJValidator(string errorMessage = "O CPF ou CNPJ é inválido!", DateTime? alphaStartDate = default)
+        {
+            _errorMessage = errorMessage;
+            _cpf = new CpfValidator<T, TProperty>();
+            _cnpj = new CNPJValidator<T, TProperty>(alphaStartDate: alphaStartDate);
+        }
+
+        public override string Name => "CpfCnpjValidator";
+
+        protected override string GetDefaultMessageTemplate(string errorCode)
+            => string.IsNullOrWhiteSpace(_errorMessage) ? base.GetDefaultMessageTemplate(errorCode) : _errorMessage;
+
+        public override bool IsValid(ValidationContext<T> context, TProperty value)
+            => _cpf.IsValid(context, value) || _cnpj.IsValid(context, value);
+    }
+}

--- a/src/FluentValidation.Extensions.Br/Validators/CPFValidator.cs
+++ b/src/FluentValidation.Extensions.Br/Validators/CPFValidator.cs
@@ -1,24 +1,25 @@
-﻿namespace FluentValidation.Validators
+namespace FluentValidation.Validators
 {
-    /// <summary>
-    /// Ensures that the property value is a valid CPF number.
-    /// </summary>
-    public class CPFValidator<T, TProperty> : GenericPersonValidator<T, TProperty>
+    using System;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+
+    public class CpfValidator<T, TProperty> : GenericPersonValidator<T, TProperty>
     {
-        internal CPFValidator(int validLength, string errorMessage) 
-            : base(validLength, errorMessage)
-        { }
+        public CpfValidator(string errorMessage = "O CPF é inválido!")
+            : base(errorMessage) { }
 
-        public CPFValidator(string errorMessage)
-            : this(11, errorMessage)
-        { }
-
-        public CPFValidator()
-            : this("O CPF é inválido!")
-        { }
-
-        protected override int[] FirstMultiplierCollection => new int[9] { 10, 9, 8, 7, 6, 5, 4, 3, 2 };
-        protected override int[] SecondMultiplierCollection => new int[10] { 11, 10, 9, 8, 7, 6, 5, 4, 3, 2 };
+        protected override int ValidLength => 11;
+        protected override int[] FirstMultiplierCollection => new[] { 10, 9, 8, 7, 6, 5, 4, 3, 2 };
+        protected override int[] SecondMultiplierCollection => new[] { 11, 10, 9, 8, 7, 6, 5, 4, 3, 2 };
         public override string Name => "CPFValidator";
+
+        protected override string Sanitize(string value)
+        {
+            if (value.Any(char.IsLetter))
+                return string.Empty;
+
+            return Regex.Replace(value, "[^0-9]", "", RegexOptions.None, TimeSpan.FromSeconds(1));
+        }
     }
 }

--- a/src/FluentValidation.Extensions.Br/Validators/GenericPersonValidator.cs
+++ b/src/FluentValidation.Extensions.Br/Validators/GenericPersonValidator.cs
@@ -1,70 +1,66 @@
-﻿namespace FluentValidation.Validators
+namespace FluentValidation.Validators
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
-    using System.Text.RegularExpressions;
 
-
-    /// <summary>
-    /// Base class for brazilian person´s document validation (CPF/CNPJ).
-    /// </summary>
     public abstract class GenericPersonValidator<T, TProperty> : PropertyValidator<T, TProperty>, IBrazilianPropertyValidator
     {
-        private readonly int validLength;
-        private readonly string errorMessage;
+        private readonly string _errorMessage;
 
+        protected abstract int ValidLength { get; }
         protected abstract int[] FirstMultiplierCollection { get; }
         protected abstract int[] SecondMultiplierCollection { get; }
 
-        protected GenericPersonValidator(int validLength, string errorMessage)
+        protected GenericPersonValidator(string errorMessage)
         {
-            this.validLength = validLength;
-            this.errorMessage = errorMessage;
+            _errorMessage = errorMessage;
         }
 
         protected override string GetDefaultMessageTemplate(string errorCode)
-        {
-            return string.IsNullOrWhiteSpace(errorMessage) ? base.GetDefaultMessageTemplate(errorCode) : errorMessage;
-        }
+            => string.IsNullOrWhiteSpace(_errorMessage) ? base.GetDefaultMessageTemplate(errorCode) : _errorMessage;
+
+        protected abstract string Sanitize(string value);
+
+        protected virtual int[] GetNumericValues(string sanitized)
+            => sanitized.Select(x => (int)char.GetNumericValue(x)).ToArray();
 
         public override bool IsValid(ValidationContext<T> context, TProperty value)
         {
-            var val = value as string ?? string.Empty;
-            val = Regex.Replace(val, "[^a-zA-Z0-9]", "");
+            if (EqualityComparer<TProperty>.Default.Equals(value, default)) return false;
 
-            if (IsValidLength(val) || 
-                AllDigitsAreEqual(val) || 
-                value == null) return false;
+            var val = Sanitize(value as string ?? string.Empty);
 
-            var cpf = val.Select(x => (int)char.GetNumericValue(x)).ToArray();
-            var digits = GetDigits(cpf);
+            if (val.Length != ValidLength || AllDigitsAreEqual(val))
+                return false;
 
-            return val.EndsWith(digits);
+            var numbers = GetNumericValues(val);
+
+            return val.EndsWith(GetCheckDigits(numbers));
         }
 
-        static bool AllDigitsAreEqual (string value) => value.All(x => x == value.FirstOrDefault());
+        private static bool AllDigitsAreEqual(string value)
+            => value.Distinct().Count() == 1;
 
-        bool IsValidLength (string value) => !string.IsNullOrWhiteSpace(value) && value.Length != validLength;
-
-        string GetDigits(int[] cpf)
+        private string GetCheckDigits(int[] numbers)
         {
-            var first = CalculateValue(FirstMultiplierCollection, cpf);
-            var second = CalculateValue(SecondMultiplierCollection, cpf);
-
+            var first = CalculateValue(FirstMultiplierCollection, numbers);
+            var second = CalculateValue(SecondMultiplierCollection, numbers);
             return $"{CalculateDigit(first)}{CalculateDigit(second)}";
         }
 
-        static int CalculateValue(int[] weight, int[] numbers)
+        private static int CalculateValue(int[] weights, int[] numbers)
         {
             var sum = 0;
-            for (int i = 0; i < weight.Length; i++) sum += weight[i] * numbers[i];
+            for (int i = 0; i < weights.Length; i++)
+                sum += weights[i] * numbers[i];
             return sum;
         }
 
-        static int CalculateDigit(int sum)
+        private static int CalculateDigit(int sum)
         {
-            int modResult = (sum % 11);
-            return modResult < 2 ? 0 : 11 - modResult;
+            var mod = sum % 11;
+            return mod < 2 ? 0 : 11 - mod;
         }
     }
 }

--- a/test/FluentValidation.Extensions.Br.Test/CNPJValidatorTests.cs
+++ b/test/FluentValidation.Extensions.Br.Test/CNPJValidatorTests.cs
@@ -1,18 +1,47 @@
-﻿namespace FluentValidation.Extensions.Br.Test
+namespace FluentValidation.Extensions.Br.Test
 {
+    using System;
     using Results;
+    using Validators;
     using Xunit;
     using System.Linq;
 
     public class CNPJValidatorTests
     {
-        [Fact]
-        public void When_CNPJ_Is_Valid_Then_The_Validator_Should_Pass ()
+        [Theory]
+        [InlineData("11.434.325/0001-07")]  // numeric with mask
+        [InlineData("11434325000107")]       // numeric without mask
+        public void When_CNPJ_Is_Valid_Then_The_Validator_Should_Pass(string cnpj)
         {
             TestExtensionsValidator validator = new TestExtensionsValidator(x => x.RuleFor(r => r.CNPJ).IsValidCNPJ());
-            ValidationResult result = validator.Validate(new Person { CNPJ = "11.434.325/0001-07" });
+            ValidationResult result = validator.Validate(new Person { CNPJ = cnpj });
 
             Assert.True(result.IsValid);
+        }
+
+        [Theory]
+        [InlineData("12.ABC.345/01DE-35")]  // alphanumeric with mask
+        [InlineData("12ABC34501DE35")]       // alphanumeric without mask
+        public void When_CNPJ_Is_Alphanumeric_And_AlphaStartDate_Has_Passed_Then_The_Validator_Should_Pass(string cnpj)
+        {
+            TestExtensionsValidator validator = new TestExtensionsValidator(
+                x => x.RuleFor(r => r.CNPJ).SetValidator(new CNPJValidator<Person, string>(alphaStartDate: new DateTime(2000, 1, 1)))
+            );
+            ValidationResult result = validator.Validate(new Person { CNPJ = cnpj });
+
+            Assert.True(result.IsValid);
+        }
+
+        [Theory]
+        [InlineData("12.ABC.345/01DE-35")]  // alphanumeric with mask — rejected before alpha start date
+        [InlineData("12ABC34501DE35")]       // alphanumeric without mask — rejected before alpha start date
+        public void When_CNPJ_Is_Alphanumeric_Before_AlphaStartDate_Then_The_Validator_Should_Fail(string cnpj)
+        {
+            TestExtensionsValidator validator = new TestExtensionsValidator(x => x.RuleFor(r => r.CNPJ).IsValidCNPJ());
+            ValidationResult result = validator.Validate(new Person { CNPJ = cnpj });
+
+            Assert.False(result.IsValid);
+            Assert.Equal("O CNPJ é inválido!", result.Errors.First().ErrorMessage);
         }
 
         [Fact]
@@ -29,19 +58,20 @@
             Assert.Equal(customMessage, errorMessage);
         }
 
-
         [Theory]
-        [InlineData("14.442.344/1210-57")] 
-        [InlineData("11.434.3215/00123-57")] 
+        [InlineData("14.442.344/1210-57")]
+        [InlineData("11.434.3215/00123-57")]
         [InlineData("A11.434.325/0001-07")]
         [InlineData("11.434.325/0001-07a")]
-        public void When_CNPJ_Is_Invalid_Then_The_Validator_Should_Fail (string cnpj)
+        [InlineData("12.ABC.345/01DE-99")]   // alphanumeric with wrong check digits
+        [InlineData("12.abc.345/01de-35")]   // lowercase letters are invalid per Receita Federal spec
+        public void When_CNPJ_Is_Invalid_Then_The_Validator_Should_Fail(string cnpj)
         {
             TestExtensionsValidator validator = new TestExtensionsValidator(x => x.RuleFor(r => r.CNPJ).IsValidCNPJ());
             ValidationResult result = validator.Validate(new Person { CNPJ = cnpj });
 
             Assert.False(result.IsValid);
-            Assert.Equal(result.Errors.First().ErrorMessage, "O CNPJ é inválido!");
+            Assert.Equal("O CNPJ é inválido!", result.Errors.First().ErrorMessage);
         }
     }
 }

--- a/test/FluentValidation.Extensions.Br.Test/CPFValidatorTests.cs
+++ b/test/FluentValidation.Extensions.Br.Test/CPFValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentValidation.Extensions.Br.Test
+namespace FluentValidation.Extensions.Br.Test
 {
     using Results;
     using Xunit;
@@ -6,11 +6,13 @@
 
     public class CPFValidatorTests
     {
-        [Fact]
-        public void When_CPF_Is_Valid_Then_The_Validator_Should_Pass()
+        [Theory]
+        [InlineData("822.420.106-62")]  // with mask
+        [InlineData("82242010662")]      // without mask
+        public void When_CPF_Is_Valid_Then_The_Validator_Should_Pass(string cpf)
         {
             TestExtensionsValidator validator = new TestExtensionsValidator(x => x.RuleFor(r => r.CPF).IsValidCPF());
-            ValidationResult result = validator.Validate(new Person { CPF = "822.420.106-62" });
+            ValidationResult result = validator.Validate(new Person { CPF = cpf });
 
             Assert.True(result.IsValid);
         }
@@ -29,7 +31,6 @@
             Assert.Equal(customMessage, errorMessage);
         }
 
-
         [Theory]
         [InlineData("144.442.344-57")]
         [InlineData("543.434.321-76")]
@@ -41,8 +42,7 @@
             ValidationResult result = validator.Validate(new Person { CPF = cpf });
 
             Assert.False(result.IsValid);
-            Assert.Equal(result.Errors.First().ErrorMessage, "O CPF é inválido!");
+            Assert.Equal("O CPF é inválido!", result.Errors.First().ErrorMessage);
         }
-
     }
 }

--- a/test/FluentValidation.Extensions.Br.Test/CpfCnpjValidatorTests.cs
+++ b/test/FluentValidation.Extensions.Br.Test/CpfCnpjValidatorTests.cs
@@ -1,0 +1,82 @@
+namespace FluentValidation.Extensions.Br.Test
+{
+    using System;
+    using Results;
+    using Validators;
+    using Xunit;
+    using System.Linq;
+
+    public class CpfCnpjValidatorTests
+    {
+        [Theory]
+        [InlineData("822.420.106-62")]       // CPF with mask
+        [InlineData("82242010662")]           // CPF without mask
+        [InlineData("11.434.325/0001-07")]   // numeric CNPJ with mask
+        [InlineData("11434325000107")]        // numeric CNPJ without mask
+        public void When_CpfOrCnpj_Is_Valid_Then_The_Validator_Should_Pass(string value)
+        {
+            TestExtensionsValidator validator = new TestExtensionsValidator(x => x.RuleFor(r => r.CpfOrCnpj).IsValidCpfOrCnpj());
+            ValidationResult result = validator.Validate(new Person { CpfOrCnpj = value });
+
+            Assert.True(result.IsValid);
+        }
+
+        [Theory]
+        [InlineData("12.ABC.345/01DE-35")]   // alphanumeric CNPJ with mask
+        [InlineData("12ABC34501DE35")]        // alphanumeric CNPJ without mask
+        public void When_CpfOrCnpj_Is_Alphanumeric_Cnpj_And_AlphaStartDate_Has_Passed_Then_The_Validator_Should_Pass(string value)
+        {
+            TestExtensionsValidator validator = new TestExtensionsValidator(
+                x => x.RuleFor(r => r.CpfOrCnpj).SetValidator(new CPFCNPJValidator<Person, string>(alphaStartDate: new DateTime(2000, 1, 1)))
+            );
+            ValidationResult result = validator.Validate(new Person { CpfOrCnpj = value });
+
+            Assert.True(result.IsValid);
+        }
+
+        [Theory]
+        [InlineData("12.ABC.345/01DE-35")]   // alphanumeric CNPJ with mask — rejected before alpha start date
+        [InlineData("12ABC34501DE35")]        // alphanumeric CNPJ without mask — rejected before alpha start date
+        public void When_CpfOrCnpj_Is_Alphanumeric_Cnpj_Before_AlphaStartDate_Then_The_Validator_Should_Fail(string value)
+        {
+            TestExtensionsValidator validator = new TestExtensionsValidator(x => x.RuleFor(r => r.CpfOrCnpj).IsValidCpfOrCnpj());
+            ValidationResult result = validator.Validate(new Person { CpfOrCnpj = value });
+
+            Assert.False(result.IsValid);
+            Assert.Equal("O CPF ou CNPJ é inválido!", result.Errors.First().ErrorMessage);
+        }
+
+        [Fact]
+        public void When_CpfOrCnpj_Is_Invalid_Then_Set_Custom_Message_And_Validator_Should_Fail()
+        {
+            const string customMessage = "Custom Message";
+
+            TestExtensionsValidator validator = new TestExtensionsValidator(x => x.RuleFor(r => r.CpfOrCnpj).IsValidCpfOrCnpj().WithMessage(customMessage));
+            ValidationResult result = validator.Validate(new Person { CpfOrCnpj = "000.000.000-00" });
+
+            string errorMessage = result.Errors.FirstOrDefault()?.ErrorMessage ?? string.Empty;
+
+            Assert.False(result.IsValid);
+            Assert.Equal(customMessage, errorMessage);
+        }
+
+        [Theory]
+        [InlineData("144.442.344-57")]
+        [InlineData("14.442.344/1210-57")]
+        [InlineData("12.ABC.345/01DE-99")]   // alphanumeric CNPJ with wrong check digits
+        [InlineData("A822.420.106-62")]
+        [InlineData("11.434.325/0001-07a")]
+        [InlineData("000.000.000-00")]
+        [InlineData("00.000.000/0000-00")]
+        [InlineData(null)]
+        [InlineData("")]
+        public void When_CpfOrCnpj_Is_Invalid_Then_The_Validator_Should_Fail(string value)
+        {
+            TestExtensionsValidator validator = new TestExtensionsValidator(x => x.RuleFor(r => r.CpfOrCnpj).IsValidCpfOrCnpj());
+            ValidationResult result = validator.Validate(new Person { CpfOrCnpj = value });
+
+            Assert.False(result.IsValid);
+            Assert.Equal("O CPF ou CNPJ é inválido!", result.Errors.First().ErrorMessage);
+        }
+    }
+}

--- a/test/FluentValidation.Extensions.Br.Test/FluentValidation.Extensions.Br.Test.csproj
+++ b/test/FluentValidation.Extensions.Br.Test/FluentValidation.Extensions.Br.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,7 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />  
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FluentValidation.Extensions.Br.Test/Person.cs
+++ b/test/FluentValidation.Extensions.Br.Test/Person.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace FluentValidation.Extensions.Br.Test
 {
     public class Person
     {
         public string CPF { get; set; }
         public string CNPJ { get; set; }
+        public string CpfOrCnpj { get; set; }
     }
 }

--- a/test/FluentValidator.Extensions.Br.Tests.Api/.claude/settings.local.json
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet build *)"
+    ]
+  }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/Controllers/Validators.cs
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/Controllers/Validators.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using FluentValidator.Extensions.Br.Tests.Api.Dtos;
+using FluentValidator.Extensions.Br.Tests.Api.Validators;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FluentValidator.Extensions.Br.Tests.Api.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class Validators : ControllerBase
+    {                
+
+        [HttpPost]
+        public ObjectResult Post([FromBody] GetValidatorRequest request)
+        {
+            IValidator<string> validator = request.Type switch
+            {
+                DocumentType.CPF => new CpfValidator(),
+                DocumentType.CNPJ => new CnpjValidator(),
+                _ => new CpfCnpjValidator()
+            };
+
+            var validation = validator.Validate(request.Document!);
+            if (validation.IsValid)
+            {
+                return new OkObjectResult(true);
+            }
+
+            return new BadRequestObjectResult(string.Concat(validation.Errors.Select(x => x.ErrorMessage)));
+        }
+    }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/Dtos/GetValidatorRequest.cs
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/Dtos/GetValidatorRequest.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+
+namespace FluentValidator.Extensions.Br.Tests.Api.Dtos
+{
+    public enum DocumentType
+    {
+        [Description("Undefined")]
+        UNDEFINED,
+        [Description("CPF")]
+        CPF,
+        [Description("CNPJ")]
+        CNPJ
+    }
+    public class GetValidatorRequest
+    {
+        public string? Document { get; set; }
+        public DocumentType? Type { get; set; }
+    }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/FluentValidator.Extensions.Br.Tests.Api.csproj
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/FluentValidator.Extensions.Br.Tests.Api.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="10.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FluentValidation.Extensions.Br\FluentValidation.Extensions.Br.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/FluentValidator.Extensions.Br.Tests.Api/FluentValidator.Extensions.Br.Tests.Api.http
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/FluentValidator.Extensions.Br.Tests.Api.http
@@ -1,0 +1,6 @@
+@FluentValidator.Extensions.Br.Tests.Api_HostAddress = http://localhost:5258
+
+GET {{FluentValidator.Extensions.Br.Tests.Api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/test/FluentValidator.Extensions.Br.Tests.Api/Infrastructure/DescriptionEnumConverter.cs
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/Infrastructure/DescriptionEnumConverter.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FluentValidator.Extensions.Br.Tests.Api.Infrastructure;
+
+public class DescriptionEnumConverterFactory : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsEnum;
+
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var converterType = typeof(DescriptionEnumConverter<>).MakeGenericType(typeToConvert);
+        return (JsonConverter)Activator.CreateInstance(converterType)!;
+    }
+}
+
+public class DescriptionEnumConverter<T> : JsonConverter<T> where T : struct, Enum
+{
+    private readonly Dictionary<string, T> _descriptionToEnum;
+    private readonly Dictionary<T, string> _enumToDescription;
+
+    public DescriptionEnumConverter()
+    {
+        _descriptionToEnum = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+        _enumToDescription = new Dictionary<T, string>();
+
+        foreach (var value in Enum.GetValues<T>())
+        {
+            var member = typeof(T).GetMember(value.ToString())[0];
+            var description = member.GetCustomAttribute<DescriptionAttribute>()?.Description ?? value.ToString();
+            _descriptionToEnum[description] = value;
+            _enumToDescription[value] = description;
+        }
+    }
+
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var str = reader.GetString();
+        if (str is not null && _descriptionToEnum.TryGetValue(str, out var value))
+            return value;
+
+        throw new JsonException($"Value '{str}' is not valid for enum {typeof(T).Name}. Valid values: {string.Join(", ", _descriptionToEnum.Keys)}");
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(_enumToDescription[value]);
+    }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/Infrastructure/EnumDescriptionSchemaFilter.cs
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/Infrastructure/EnumDescriptionSchemaFilter.cs
@@ -1,0 +1,26 @@
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace FluentValidator.Extensions.Br.Tests.Api.Infrastructure;
+
+public class EnumDescriptionSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (!context.Type.IsEnum) return;
+
+        schema.Enum.Clear();
+        schema.Type = "string";
+        schema.Format = null;
+
+        foreach (var value in Enum.GetValues(context.Type))
+        {
+            var member = context.Type.GetMember(value.ToString()!)[0];
+            var description = member.GetCustomAttribute<DescriptionAttribute>()?.Description ?? value.ToString();
+            schema.Enum.Add(new OpenApiString(description!));
+        }
+    }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/Program.cs
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/Program.cs
@@ -1,0 +1,28 @@
+using FluentValidator.Extensions.Br.Tests.Api.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+        options.JsonSerializerOptions.Converters.Add(new DescriptionEnumConverterFactory()));
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+    options.SchemaFilter<EnumDescriptionSchemaFilter>());
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+await app.RunAsync();

--- a/test/FluentValidator.Extensions.Br.Tests.Api/Validators/CnpjValidator.cs
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/Validators/CnpjValidator.cs
@@ -1,0 +1,15 @@
+﻿using FluentValidation;
+using System.Data;
+
+namespace FluentValidator.Extensions.Br.Tests.Api.Validators
+{
+    public class CnpjValidator : AbstractValidator<string>
+    {
+        public CnpjValidator()
+        {
+            RuleFor(x => x)
+                .IsValidCNPJ()
+                .WithMessage("CNPJ Inválido.");
+        }
+    }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/Validators/CpfCnpjValidator.cs
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/Validators/CpfCnpjValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+
+namespace FluentValidator.Extensions.Br.Tests.Api.Validators
+{
+    public class CpfCnpjValidator : AbstractValidator<string>
+    {
+        public CpfCnpjValidator()
+        {
+            RuleFor(x => x)
+                .IsValidCpfOrCnpj()
+                .WithMessage("Documento inválido.");
+        }
+    }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/Validators/CpfValidator.cs
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/Validators/CpfValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+
+namespace FluentValidator.Extensions.Br.Tests.Api.Validators
+{
+    public class CpfValidator : AbstractValidator<string>
+    {
+        public CpfValidator()
+        {
+            RuleFor(x => x.Trim())
+                .IsValidCPF()
+                .WithMessage("CPF Inválido.");
+        }
+    }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/appsettings.Development.json
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/test/FluentValidator.Extensions.Br.Tests.Api/appsettings.json
+++ b/test/FluentValidator.Extensions.Br.Tests.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
This PR refact a bit the code and prepare code for start validating alphanumeric cnpjs in 07/01/2026 (July first, 2026).
As this project is a lib it is setted in hardcoded, cuz if not, every person should create an environment var into their project, then, according the (Receita Federal Doc)[https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/perguntas-e-respostas/cnpj/cnpj-alfanumerico.pdf] it was setted hard coded into code.

But there are unit tests who allow you to test the project.

Was included an API project just for someone who wants to run and test it by yourself, but, the actual API implementation will use original data, then, before the alphanumeric CNPJ start date, every alphanumeric CNPJ passed will return false.

As an extra was implemented a new Validator, who allows user validate CpfOrCnpj, using CPFCNPJValidator class.